### PR TITLE
Fix Chat not working properly

### DIFF
--- a/FrontEnd/src/components/ChatBar/index.jsx
+++ b/FrontEnd/src/components/ChatBar/index.jsx
@@ -13,7 +13,7 @@ useEffect(()=>{
         return () => socket.off("messageResponse")
     })
 
-},[chat,socket])
+},[]) // Register the event only once
 
 function handleSubmit(e){
     e.preventDefault()


### PR DESCRIPTION
## What does this PR do?
There was a bug with the chat where messages were being replicated at the receiver's end. The root cause for this was the re-registration of listeners for "messageResponse" event in the client code. The PR fixes this bug.

## Test Plan
Testing type: Manual

Before:
![image](https://github.com/Khanak21/Whiteboard/assets/31096082/065bbd09-6ee0-4cf1-b7ac-883318234fad)

After:
![image](https://github.com/Khanak21/Whiteboard/assets/31096082/a666cfce-4f24-466e-ac4d-d868da77d6a6)


## Related PRs and Issues
Issue #2 Bug - Chat not working properly 

